### PR TITLE
Add deseasonalize + dct functions to promql

### DIFF
--- a/promql/dct.go
+++ b/promql/dct.go
@@ -1,0 +1,108 @@
+package promql
+
+// import (
+	// "errors"
+	// "math"
+// )
+
+// type Name Actual
+
+// Index is meant to wrap int, but be 0 indexed, i.e. non-negative, for value
+// slices.
+type Index = int
+
+// Value represents the input space and is meant to make it easier to codemod
+type Value = float64
+
+// FValue represents the frequency space
+type FValue = float64
+
+type matrix = [][]Value
+
+// IndexInvalid is the only negative value of type Index allowed
+const IndexInvalid = Index(-1)
+
+// Normalization?
+// scipy's default (None), i.e. ??
+// matlab's default, scipy's "ortho", i.e. ??
+// scipy.fftpack.dct(np.array([4, 3, 5, 10]), type=1, norm=None)
+
+// DCT type 1
+func DCT1(vals []Value) []FValue {
+	n := len(vals)
+	if n == 0 {
+		return nil
+	}
+	ret := make([]FValue, n)
+	return ret
+}
+
+// DCT type 2, the default DCT
+func DCT2(vals []Value) []FValue {
+	n := len(vals)
+	if n == 0 {
+		return nil
+	}
+	ret := make([]FValue, n)
+	return ret
+}
+
+// DCT type 3, the default IDCT
+func DCT3(vals []Value) []FValue {
+	n := len(vals)
+	if n == 0 {
+		return nil
+	}
+	ret := make([]FValue, n)
+	return ret
+}
+
+// DCT type 4
+func DCT4(vals []Value) []FValue {
+	n := len(vals)
+	if n == 0 {
+		return nil
+	}
+	ret := make([]FValue, n)
+	return ret
+}
+
+// DCT default function is DCT type 2
+var DCT = DCT2
+
+// IDCT default function is DCT type 3
+var IDCT = DCT3
+
+// RotateToMax returns the index of the max value in the input slice and a slice
+// rotated to that point. If an empty slice is used, it returns -1, nil
+// TODO testify https://go.dev/play/p/pBXY74jDMW1
+func RotateToMax(vals []Value) (Index, []Value) {
+	n := len(vals)
+	if n == 0 {
+		return IndexInvalid, nil
+	}
+	maxI := Index(0)
+	var maxV *Value
+	for i, v := range vals {
+		if maxV == nil || v > *maxV {
+			maxI = i
+			maxV = &vals[i]
+		}
+	}
+	return maxI, append(vals[maxI:n], vals[0:maxI]...)
+}
+
+// identity returns an identity matrix of size n x n
+func identity(n Index) matrix {
+	mat := make([][]Value, n)
+	for i := 0; i <= n; i++ {
+		// TODO add `1` at index `i`
+		mat = append(mat, make([]Value, n))
+	}
+	return mat
+}
+
+// matMult returns the matrix multiplied result of m * n
+func matMult(m, n matrix) (matrix) {
+	return nil
+}

--- a/promql/dct.go
+++ b/promql/dct.go
@@ -1,9 +1,10 @@
 package promql
 
-// import (
+import (
+	"context"
 	// "errors"
-	// "math"
-// )
+	"math"
+)
 
 // type Name Actual
 
@@ -17,7 +18,11 @@ type Value = float64
 // FValue represents the frequency space
 type FValue = float64
 
+// matrix is a slice of column values. Example accessor: `mat[rowI][colJ]`
 type matrix = [][]Value
+
+// column is a slice of values
+type column = []Value
 
 // IndexInvalid is the only negative value of type Index allowed
 const IndexInvalid = Index(-1)
@@ -25,20 +30,44 @@ const IndexInvalid = Index(-1)
 // Normalization?
 // scipy's default (None), i.e. ??
 // matlab's default, scipy's "ortho", i.e. ??
-// scipy.fftpack.dct(np.array([4, 3, 5, 10]), type=1, norm=None)
+// TODO scipy.fftpack.dct(np.array([4, 3, 5, 10]), type=1, norm=None)
+
+// Notes from https://en.wikipedia.org/wiki/Discrete_cosine_transform#DCT-I
+// X_k is the output value in the k-th column.
+// x_k is the input value in the k-th column.
+
+// https://docs.scipy.org/doc/scipy/reference/generated/scipy.fftpack.dct.html
 
 // DCT type 1
-func DCT1(vals []Value) []FValue {
+func DCT1(ctx context.Context, vals []Value) []FValue {
 	n := len(vals)
-	if n == 0 {
+	if n <= 1 {
 		return nil
 	}
-	ret := make([]FValue, n)
-	return ret
+	// TODO check "identity" cache
+	dctMat := make(matrix, n)
+	for i := 0; i < n; i++ {
+		dctMat[i] = make([]Value, n)
+		for j := 0; j < n; j++ {
+			// TODO why did we normalize everything by 2?
+			if i == 0 {
+				dctMat[i][j] = 1 // 0.5
+				continue
+			} else if i == n - 1 && j % 2 == 0 {
+				dctMat[i][j] = 1 // 0.5
+				continue
+			} else if i == n - 1 {
+				dctMat[i][j] = -1 // -0.5
+				continue
+			}
+			dctMat[i][j] = math.Cos((math.Pi / float64(n - 1)) * float64(i) * float64(j)) * 2
+		}
+	}
+	return matMult(matrix{vals}, dctMat)[0]
 }
 
 // DCT type 2, the default DCT
-func DCT2(vals []Value) []FValue {
+func DCT2(ctx context.Context, vals []Value) []FValue {
 	n := len(vals)
 	if n == 0 {
 		return nil
@@ -48,7 +77,7 @@ func DCT2(vals []Value) []FValue {
 }
 
 // DCT type 3, the default IDCT
-func DCT3(vals []Value) []FValue {
+func DCT3(ctx context.Context, vals []Value) []FValue {
 	n := len(vals)
 	if n == 0 {
 		return nil
@@ -58,7 +87,7 @@ func DCT3(vals []Value) []FValue {
 }
 
 // DCT type 4
-func DCT4(vals []Value) []FValue {
+func DCT4(ctx context.Context, vals []Value) []FValue {
 	n := len(vals)
 	if n == 0 {
 		return nil
@@ -92,9 +121,29 @@ func RotateToMax(vals []Value) (Index, []Value) {
 	return maxI, append(vals[maxI:n], vals[0:maxI]...)
 }
 
+// Unrotate takes the original index that the max was at, and reverses the
+// transformation that RotateToMax applies. It will return an empty slice if
+// it's passed an empty slice, or an invalid index.
+func Unrotate(i Index, vals []Value) []Value {
+	n := len(vals)
+	if n == 0 || i == IndexInvalid || i >= n {
+		return nil
+	}
+	return append(vals[n-i:], vals[0:n-i]...)
+}
+
+var identityCache map[Index]matrix
+
 // identity returns an identity matrix of size n x n
-func identity(n Index) matrix {
-	mat := make([][]Value, n)
+func identity(ctx context.Context, n Index) matrix {
+	if identityCache == nil {
+		identityCache = make(map[Index]matrix)
+	}
+	v, ok := identityCache[n]
+	if ok {
+		return v
+	}
+	mat := make(matrix, n)
 	for i := 0; i <= n; i++ {
 		// TODO add `1` at index `i`
 		mat = append(mat, make([]Value, n))
@@ -102,7 +151,59 @@ func identity(n Index) matrix {
 	return mat
 }
 
+// transpose returns the transposed matrix
+func transpose(m matrix) matrix {
+	nRows := len(m)
+	if nRows == 0 {
+		return nil
+	}
+	nCols := len(m[0])
+	if nCols == 0 {
+		return nil
+	}
+	ret := make(matrix, nCols)
+	for i := 0; i < nCols; i++ {
+		// ret = append(ret, make([]Value, nRows))
+		ret[i] = make([]Value, nRows)
+	}
+	for i := 0; i < nCols; i++ {
+		for j := 0; j < nRows; j++ {
+			ret[i][j] = m[j][i]
+		}
+	}
+	return ret
+}
+
 // matMult returns the matrix multiplied result of m * n
-func matMult(m, n matrix) (matrix) {
-	return nil
+func matMult(m, n matrix) matrix {
+	mRows := len(m)
+	if mRows == 0 {
+		return nil
+	}
+	mCols := len(m[0])
+	if mCols == 0 {
+		return nil
+	}
+	nRows := len(n)
+	if nRows == 0 {
+		return nil
+	}
+	nCols := len(n[0])
+	if nCols == 0 {
+		return nil
+	}
+	if mCols != nCols {
+		// Maybe return an error instead?
+		return nil
+	}
+	ret := make(matrix, mRows)
+	for i := 0; i < mRows; i++ {
+		ret[i] = make([]Value, nCols)
+		for j := 0; j < nCols; j++ {
+			for k := 0; k < mCols; k++ {
+				ret[i][j] += m[i][k] * n[k][j]
+			}
+		}
+	}
+	return ret
 }

--- a/promql/dct_test.go
+++ b/promql/dct_test.go
@@ -1,0 +1,39 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql_test
+
+import (
+	"context"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/prometheus/prometheus/promql"
+)
+
+func TestRotate(t *testing.T) {
+	vals := []float64{4, 3, 5, 10}
+	i, rotated := promql.RotateToMax(vals)
+	require.Equal(t, 3, i)
+	require.Equal(t, []float64{10, 4, 3, 5}, rotated)
+	recovered := promql.Unrotate(i, rotated)
+	require.Equal(t, vals, recovered)
+}
+
+func TestDCT(t *testing.T) {
+	ctx := context.Background()
+	// Example values from https://docs.scipy.org/doc/scipy/reference/generated/scipy.fftpack.dct.html
+	vals := []float64{4, 3, 5, 10}
+	require.InDeltaSlice(t, []float64{30, -8, 6, -2}, promql.DCT1(ctx, vals), 1e-6)
+}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1063,6 +1063,46 @@ func funcYear(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper)
 	})
 }
 
+// === deseasonalize(...) Vector ===
+func funcDeseasonalize(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) Vector {
+	// See funcVector or funcPredictLinear or funcHoltWinters for examples
+	// TODO this seems to be a scalar?
+	nFreqs := vals[0].(Vector)[0].V
+	samples := vals[1].(Matrix)[0]
+
+	nPoints := len(samples.Points)
+	if nPoints == 0 {
+		return enh.Out
+	}
+
+	if nFreqs == 0 {
+		for i := 0; i < nPoints; i++ {
+			enh.Out = append(enh.Out, Sample{
+				Point: samples.Points[i],
+			})
+		}
+		return enh.Out
+	}
+
+	// TODO rotated, i  := RotateToMax([samples.Points[i].V for i in range nFreqs])
+	// TODO freqs := DCT(rotated)
+	// TODO sorted := sortHeap(freqs, nFreqs)
+	// TODO for i, _ := sorted { freqs[i] = 0 }
+	// TODO altered := IDCT(freqs)
+	// TODO return Unrotate(i, altered)
+
+	// sortHeap := import container/heap. heap := IntHeap(nFreqs). compare/push all elements. pop just nFreqs.
+
+	// Point: samples.Points[i].V,
+	// samples.Points[i].V
+
+	// TODO try returning a Matrix
+	return append(enh.Out, Sample{
+		// Metric: labels.Labels{},
+		Point:  Point{V: nFreqs},
+	})
+}
+
 // FunctionCalls is a list of all functions supported by PromQL, including their types.
 var FunctionCalls = map[string]FunctionCall{
 	"abs":                funcAbs,
@@ -1089,6 +1129,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"deg":                funcDeg,
 	"delta":              funcDelta,
 	"deriv":              funcDeriv,
+	"deseasonalize":      funcDeseasonalize,
 	"exp":                funcExp,
 	"floor":              funcFloor,
 	"histogram_quantile": funcHistogramQuantile,

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -147,6 +147,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"deseasonalize": {
+		Name:       "deseasonalize",
+		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeMatrix}, // ValueTypeVect or ValueTypeMatrix?
+		ReturnType: ValueTypeMatrix, // ValueTypeVector,
+	},
 	"exp": {
 		Name:       "exp",
 		ArgTypes:   []ValueType{ValueTypeVector},


### PR DESCRIPTION
# Description

Adds the DCT functions

# Test plan

```
make common-build
GO111MODULE=on go test -race ./promql -run TestDeseasonalize
GO111MODULE=on go test -race ./promql -run TestRotate
GO111MODULE=on go test -race ./promql -run TestDCT
dlv test ./promql -- -test.run TestDCT
# Run a query deseasonalize(0, prometheus_http_request_duration_seconds_bucket[1m])
```

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
